### PR TITLE
refactor: Replace the word "course" with "exercise"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Skills Response Templates
 
-A collection of responses for use in Skills courses.
+A collection of responses for use in Skills exercises.
 
 ## Template Collections
 
-- `/readme/*` - templates intended for updating a course's root readme file.
+- `/readme/*` - templates intended for updating an exercise's root readme file.
 - `/step-feedback/*` - templates for sharing step progress, grading pass/fail, and congratulations. Typically used for issue comments.
 
 ## Template Variables

--- a/step-feedback/lesson-finished.md
+++ b/step-feedback/lesson-finished.md
@@ -1,6 +1,6 @@
 <img src="https://octodex.github.com/images/welcometocat.png" align="left" height="150px" />
 
-Congratulations **{{ login }}**! You finished the course! 🎉🎉🎉
+Congratulations **{{ login }}**! You finished the exercise! 🎉🎉🎉
 
 We've updated the repository with a couple changes to highlight your success!
 

--- a/step-feedback/welcome.md
+++ b/step-feedback/welcome.md
@@ -2,7 +2,7 @@
 
 <img src="https://octodex.github.com/images/original.png" align="left" height="80px" />
 
-👋 Hey there {{ login }}! Welcome to your learning course!
+👋 Hey there {{ login }}! Welcome to your Skills exercise!
 
 {{ intro_message }}
 


### PR DESCRIPTION
This pull request includes several changes to rename references from "Skills Course" to "Skills Exercise" across multiple files.